### PR TITLE
Walk with mutable stop (without step-outs)

### DIFF
--- a/src/count.rs
+++ b/src/count.rs
@@ -105,7 +105,7 @@ impl<T> CountTree<T> {
 
     /// Returns the element at the given index, or `None` if index is out of
     /// bounds. Time complexity: O(log(n))
-    pub fn get<'a>(&'a self, index: usize) -> Option<&'a T> {
+    pub fn get(&self, index: usize) -> Option<&T> {
         use WalkAction::*;
 
         if index >= self.len() {
@@ -113,19 +113,19 @@ impl<T> CountTree<T> {
         } else {
             let mut val = None;
             let mut up_count = 0;
-            self.root().unwrap().walk(|node: &'a CountNode<T>| {
+            self.root().unwrap().walk(|node| {
                 index_walker!(index, node, up_count, {
                     val = Some(node.value());
                 })
             });
-            assert!(val.is_some());
+            debug_assert!(val.is_some());
             val
         }
     }
 
     /// Returns a mutable reference to the element at the given index, or `None`
     /// if out of bounds. Time complexity: O(log(n))
-    pub fn get_mut<'a>(&'a mut self, index: usize) -> Option<&'a mut T> {
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut T> {
         use WalkAction::*;
 
         if index >= self.len() {
@@ -135,10 +135,8 @@ impl<T> CountTree<T> {
             let mut up_count = 0;
             let root = self.root_must();
             root.walk_mut(|node| index_walker!(index, node, up_count, {}),
-                          |node: &'a mut CountNode<T>| {
-                              val = Some(node.value_mut());
-                          });
-            assert!(val.is_some());
+                          |node| val = Some(node.value_mut()));
+            debug_assert!(val.is_some());
             val
         }
     }
@@ -215,9 +213,7 @@ impl<T> CountTree<T> {
             let root = self.root_must();
             root.walk_extract(|node| index_walker!(index, node, up_count, {}),
                               |node, ret| {
-                                  *ret = node.try_remove(|node, _| {
-                                      node.rebalance()
-                                  });
+                                  *ret = node.try_remove(|node, _| node.rebalance());
                               },
                               |node, _| node.rebalance())
                 .unwrap()
@@ -558,11 +554,11 @@ impl<T> NodeMut for CountNode<T> {
         self.val
     }
 
-    fn left_mut<'a>(&'a mut self) -> Option<&'a mut Self> {
+    fn left_mut(&mut self) -> Option<&mut Self> {
         self.left.as_mut().map(|l| &mut **l)
     }
 
-    fn right_mut<'a>(&'a mut self) -> Option<&'a mut Self> {
+    fn right_mut(&mut self) -> Option<&mut Self> {
         self.right.as_mut().map(|r| &mut **r)
     }
 }

--- a/src/count.rs
+++ b/src/count.rs
@@ -501,6 +501,11 @@ impl<T> CountNode<T> {
             self.height += 1;
         }
     }
+
+    fn into_value(self) -> T {
+        debug_assert!(self.count == 1, "count = {}", self.count);
+        self.val
+    }
 }
 
 impl<T> Node for CountNode<T> {
@@ -550,8 +555,8 @@ impl<T> NodeMut for CountNode<T> {
         &mut self.val
     }
 
-    fn into_value(self) -> T {
-        self.val
+    fn into_parts(self) -> (T, Option<Self::NodePtr>, Option<Self::NodePtr>) {
+        (self.val, self.left, self.right)
     }
 
     fn left_mut(&mut self) -> Option<&mut Self> {

--- a/src/count.rs
+++ b/src/count.rs
@@ -123,7 +123,25 @@ impl<T> CountTree<T> {
         }
     }
 
-    // TODO get_mut or mut_with
+    /// Returns a mutable reference to the element at the given index, or `None`
+    /// if out of bounds. Time complexity: O(log(n))
+    pub fn get_mut<'a>(&'a mut self, index: usize) -> Option<&'a mut T> {
+        use WalkAction::*;
+
+        if index >= self.len() {
+            None
+        } else {
+            let mut val = None;
+            let mut up_count = 0;
+            let root = self.root_must();
+            root.walk_mut_simple(|node| index_walker!(index, node, up_count, {}),
+                                 |node: &'a mut CountNode<T>| {
+                                     val = Some(node.value_mut());
+                                 });
+            assert!(val.is_some());
+            val
+        }
+    }
 
     /// Inserts an element at the given index. Time complexity: O(log(n))
     ///
@@ -571,6 +589,9 @@ mod tests {
         assert_eq!(ct.get(2), Some(&7));
         assert_eq!(ct.get(3), Some(&5));
         assert_eq!(ct.get(4), None);
+        let mut ct = ct;
+        ct.get_mut(3).map(|v| *v = 100);
+        assert_eq!(ct.get(3), Some(&100));
     }
 
     #[test]

--- a/src/count.rs
+++ b/src/count.rs
@@ -203,7 +203,7 @@ impl<T> CountTree<T> {
                          },
                          |node, _| node.rebalance())
                 .unwrap()
-                .value_owned()
+                .into_value()
         } else if index + 1 == len {
             self.pop_back().unwrap()
         } else {
@@ -216,7 +216,7 @@ impl<T> CountTree<T> {
         if self.is_empty() {
             None
         } else if self.len() == 1 {
-            Some(self.0.take().unwrap().value_owned())
+            Some(self.0.take().unwrap().into_value())
         } else {
             let root = self.root_must();
             Some(root.extract(|_| WalkAction::Left,
@@ -228,7 +228,7 @@ impl<T> CountTree<T> {
                               },
                               |node, _| node.rebalance())
                      .unwrap()
-                     .value_owned())
+                     .into_value())
         }
     }
 
@@ -238,7 +238,7 @@ impl<T> CountTree<T> {
         if self.is_empty() {
             None
         } else if self.len() == 1 {
-            Some(self.0.take().unwrap().value_owned())
+            Some(self.0.take().unwrap().into_value())
         } else {
             let root = self.root_must();
             Some(root.extract(|_| WalkAction::Right,
@@ -250,7 +250,7 @@ impl<T> CountTree<T> {
                               },
                               |node, _| node.rebalance())
                      .unwrap()
-                     .value_owned())
+                     .into_value())
         }
     }
 
@@ -529,7 +529,11 @@ impl<T> NodeMut for CountNode<T> {
         tree
     }
 
-    fn value_owned(self) -> T {
+    fn value_mut(&mut self) -> &mut T {
+        &mut self.val
+    }
+
+    fn into_value(self) -> T {
         self.val
     }
 

--- a/src/count.rs
+++ b/src/count.rs
@@ -527,6 +527,14 @@ impl<T> NodeMut for CountNode<T> {
     fn value_owned(self) -> T {
         self.val
     }
+
+    fn left_mut<'a>(&'a mut self) -> Option<&'a mut Self> {
+        self.left.as_mut().map(|l| &mut **l)
+    }
+
+    fn right_mut<'a>(&'a mut self) -> Option<&'a mut Self> {
+        self.right.as_mut().map(|r| &mut **r)
+    }
 }
 
 #[cfg(test)]

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -74,15 +74,16 @@ impl<T> Iterator for IntoIter<T>
     fn next(&mut self) -> Option<T::Value> {
         if let Some((mut subtree, action)) = self.stack.pop() {
             if action == IterAction::Left {
-                while let Some(st) = subtree.detach_left() {
+                while let Some(left) = subtree.detach_left() {
                     self.stack.push((subtree, IterAction::Right));
-                    subtree = st;
+                    subtree = left;
                 }
             }
-            if let Some(st) = subtree.detach_right() {
+            let (value, _, right) = subtree.unbox().into_parts();
+            if let Some(st) = right {
                 self.stack.push((st, IterAction::Left));
             }
-            Some(subtree.unbox().into_value())
+            Some(value)
         } else {
             None
         }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -82,7 +82,7 @@ impl<T> Iterator for IntoIter<T>
             if let Some(st) = subtree.detach_right() {
                 self.stack.push((st, IterAction::Left));
             }
-            Some(subtree.unbox().value_owned())
+            Some(subtree.unbox().into_value())
         } else {
             None
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,10 +83,10 @@ pub trait NodeMut: Node + Sized {
     fn into_value(self) -> Self::Value;
 
     /// Returns a mutable reference to the left child
-    fn left_mut<'a>(&'a mut self) -> Option<&'a mut Self>;
+    fn left_mut(&mut self) -> Option<&mut Self>;
 
     /// Returns a mutable reference to the right child
-    fn right_mut<'a>(&'a mut self) -> Option<&'a mut Self>;
+    fn right_mut(&mut self) -> Option<&mut Self>;
 
     /// Try to rotate the tree left if right subtree exists
     fn rotate_left(&mut self) -> Result<(), ()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,8 @@ pub trait NodeMut: Node + Sized {
     /// Returns a mutable reference to the value of the current node.
     fn value_mut(&mut self) -> &mut Self::Value;
 
-    /// Consume a Node and return its value
-    fn into_value(self) -> Self::Value;
+    /// Consume a Node and return its parts: (value, left, right)
+    fn into_parts(self) -> (Self::Value, Option<Self::NodePtr>, Option<Self::NodePtr>);
 
     /// Returns a mutable reference to the left child
     fn left_mut(&mut self) -> Option<&mut Self>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,11 @@ pub trait NodeMut: Node + Sized {
     /// Replace the right subtree with `tree` and return the old one.
     fn insert_right(&mut self, tree: Option<Self::NodePtr>) -> Option<Self::NodePtr>;
 
+    /// Returns a mutable reference to the value of the current node.
+    fn value_mut(&mut self) -> &mut Self::Value;
+
     /// Consume a Node and return its value
-    fn value_owned(self) -> Self::Value;
+    fn into_value(self) -> Self::Value;
 
     /// Returns a mutable reference to the left child
     fn left_mut<'a>(&'a mut self) -> Option<&'a mut Self>;

--- a/src/test.rs
+++ b/src/test.rs
@@ -122,11 +122,11 @@ impl<T> NodeMut for TestNode<T> {
         self.val
     }
 
-    fn left_mut<'a>(&'a mut self) -> Option<&'a mut Self> {
+    fn left_mut(&mut self) -> Option<&mut Self> {
         self.left.as_mut().map(|l| &mut **l)
     }
 
-    fn right_mut<'a>(&'a mut self) -> Option<&'a mut Self> {
+    fn right_mut(&mut self) -> Option<&mut Self> {
         self.right.as_mut().map(|r| &mut **r)
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -114,7 +114,11 @@ impl<T> NodeMut for TestNode<T> {
         st
     }
 
-    fn value_owned(self) -> T {
+    fn value_mut(&mut self) -> &mut T {
+        &mut self.val
+    }
+
+    fn into_value(self) -> T {
         self.val
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -181,15 +181,15 @@ mod tests {
         let mut steps = vec![Right, Left, Stop];
         {
             let mut step_iter = steps.drain(..);
-            tt.walk_mut(|_| step_iter.next().unwrap(),
-                        |st| assert_eq!(st.val, 25),
-                        |st, action| {
-                            match action {
-                                Right => assert_eq!(st.val, 20),
-                                Left => assert_eq!(st.val, 30),
-                                Stop => unreachable!(),
-                            }
-                        });
+            tt.walk_reshape(|_| step_iter.next().unwrap(),
+                            |st| assert_eq!(st.val, 25),
+                            |st, action| {
+                                match action {
+                                    Right => assert_eq!(st.val, 20),
+                                    Left => assert_eq!(st.val, 30),
+                                    Stop => unreachable!(),
+                                }
+                            });
         }
         assert_eq!(steps.len(), 0);
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -117,6 +117,14 @@ impl<T> NodeMut for TestNode<T> {
     fn value_owned(self) -> T {
         self.val
     }
+
+    fn left_mut<'a>(&'a mut self) -> Option<&'a mut Self> {
+        self.left.as_mut().map(|l| &mut **l)
+    }
+
+    fn right_mut<'a>(&'a mut self) -> Option<&'a mut Self> {
+        self.right.as_mut().map(|r| &mut **r)
+    }
 }
 
 #[cfg(test)]

--- a/src/test.rs
+++ b/src/test.rs
@@ -118,8 +118,8 @@ impl<T> NodeMut for TestNode<T> {
         &mut self.val
     }
 
-    fn into_value(self) -> T {
-        self.val
+    fn into_parts(self) -> (T, Option<Self::NodePtr>, Option<Self::NodePtr>) {
+        (self.val, self.left, self.right)
     }
 
     fn left_mut(&mut self) -> Option<&mut Self> {


### PR DESCRIPTION
- [x] `NodeMut::walk_mut_simple`
- [x] `CountTree::get_mut`
- [ ] ~~`CountTree::swap`~~ _may be later!_

Alternate names:
- `walk_mut` -> `walk_mut_ex`, `walk_build` or `walk_reshape`
- `walk_mut_simple` -> `walk_mut` or `walk_leak`

~~Have `walk` accept a `stop` closure (then `walk_mut_simple` -> `walk_mut` will be more consistent)?~~ No!

Current renaming:
- `walk_mut` -> `walk_reshape`
- `walk_mut_simple` -> `walk_mut`
